### PR TITLE
Show scores at end of game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /cdk/node_modules
+
+# VS Code settings file
+settings.json


### PR DESCRIPTION
When a game ends, display the final scores, sorted from highest to lowest. 